### PR TITLE
Fix backtest dataset path

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -9,7 +9,7 @@ tp_percent = 0.06  # Take-profit
 trailing_percent = 0.03
 
 # === 1. Carregar CSV com dados históricos ===
-df = pd.read_csv("historico_BTCUSDT_1min.csv")  # ou outro par
+df = pd.read_csv("BTCUSDT_1min.csv")  # ou outro par
 df['timestamp'] = pd.to_datetime(df['timestamp'])
 df.set_index('timestamp', inplace=True)
 


### PR DESCRIPTION
## Summary
- use `BTCUSDT_1min.csv` for backtests

## Testing
- `python -m py_compile backtest.py`

------
https://chatgpt.com/codex/tasks/task_e_6852f2f3cc748329aef0a8c4c824d06c