### PR TITLE
Refatora fluxo de modelo e treino

### DIFF
--- a/modelo/avaliador_modelo.py
+++ b/modelo/avaliador_modelo.py
@@ -3,24 +3,27 @@ import joblib
 import base64
 from firebase_admin import firestore
 
-# === Carrega o modelo mais recente do Firestore ===
-def carregar_modelo():
+# === Função principal: prever se a próxima subida é provável ===
+def prever_subida(df_indicadores):
+    """Carrega o modelo mais recente do Firestore e faz a inferência.
+
+    Esta é a função oficial de inferência utilizada pelo bot em tempo real.
+    Recebe um DataFrame com os indicadores técnicos mais recentes e retorna
+    ``True`` caso o modelo preveja que o próximo candle será de subida.
+    """
     db = firestore.client()
     colecao = db.collection("modelos_treinados")
     docs = colecao.order_by("timestamp", direction=firestore.Query.DESCENDING).limit(1).stream()
 
+    modelo = None
     for doc in docs:
         dados = doc.to_dict()
         modelo_b64 = dados.get("modelo")
         if modelo_b64:
             modelo_bytes = base64.b64decode(modelo_b64)
             modelo = joblib.loads(modelo_bytes)
-            return modelo
-    return None
+            break
 
-# === Função principal: prever se a próxima subida é provável ===
-def prever_subida(df_indicadores):
-    modelo = carregar_modelo()
     if modelo is None:
         print("❌ Nenhum modelo disponível no Firestore.")
         return False

--- a/modelo/treino_continuo.py
+++ b/modelo/treino_continuo.py
@@ -33,13 +33,24 @@ def treinar(df):
 
     joblib.dump(modelo, "modelo_treinado.pkl")
 
-    enviar_telegram(f"🧠 Modelo re-treinado!\n🎯 Acurácia: *{acc*100:.2f}%* com {len(df)} registos.")
+    enviar_telegram(
+        f"🧠 Modelo re-treinado!\n🎯 Acurácia: *{acc*100:.2f}%* com {len(df)} registos."
+    )
     print("✅ Modelo treinado e guardado.")
     return acc
 
-if __name__ == "__main__":
+
+def executar_treino():
+    """Carrega os dados do Firestore e treina o modelo.
+
+    Pode ser chamado manualmente ou por cron jobs e retorna a acurácia
+    obtida ou ``None`` caso não haja dados suficientes.
+    """
     df = carregar_dados()
     if df.empty:
         print("⚠️ Sem dados para treino.")
-    else:
-        treinar(df)
+        return None
+    return treinar(df)
+
+if __name__ == "__main__":
+    executar_treino()

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,12 @@ python modelo/treino_modelo.py
 O arquivo `modelo_rf.pkl` será criado localmente (e está ignorado pelo Git) e
 enviado para o Firestore, de onde o bot o irá buscar automaticamente.
 
+As previsões em tempo real são feitas através da função
+`prever_subida(df_indicadores)` disponível em `modelo/avaliador_modelo.py`.
+Para re-treinar o modelo de forma contínua podes executar
+`modelo/treino_continuo.py` manualmente ou agendar a função `executar_treino()`
+num cron job.
+
 4. (Opcional) Gere indicadores técnicos com o dataset `BTCUSDT_1min.csv`:
 ```bash
 python analise_tecnica/indicadores.py


### PR DESCRIPTION
## Summary
- simplifica avaliador_modelo removendo funcao redundante
- documenta e reforca `prever_subida` como interface de inferencia
- adiciona `executar_treino` e prepara `treino_continuo` para uso por cron
- atualiza README com instrucoes de inferencia e treino continuo

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856cbecf9c883299c8adb7832623f97